### PR TITLE
implemented ability to search posts by tag

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -127,5 +127,54 @@ namespace TabloidCLI
                 }
             }
         }
+
+        public SearchResults<Post> SearchPosts(string tagName)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT p.id,
+                                               p.Title,
+                                               p.Url,
+                                               p.PublishDateTime,
+                                               p.AuthorId,
+                                               p.BlogId
+                                          FROM Post p
+                                               LEFT JOIN PostTag pt on p.Id = pt.PostId
+                                               LEFT JOIN Tag t on t.Id = pt.TagId
+                                         WHERE t.Name LIKE @name";
+                    cmd.Parameters.AddWithValue("@name", $"%{tagName}%");
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    SearchResults<Post> results = new SearchResults<Post>();
+                    while (reader.Read())
+                    {
+                        Post post = new Post()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Title = reader.GetString(reader.GetOrdinal("Title")),
+                            Url = reader.GetString(reader.GetOrdinal("Url")),
+                            PublishDateTime = reader.GetDateTime(reader.GetOrdinal("PublishDateTime")),
+                            Author = new Author
+                            {
+                                FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                                LastName = reader.GetString(reader.GetOrdinal("LastName"))
+                            },
+                            Blog = new Blog
+                            {
+                                Title = reader.GetString(reader.GetOrdinal("Title"))
+                            }
+                        };
+                        results.Add(post);
+                    }
+
+                    reader.Close();
+
+                    return results;
+                }
+            }
+        }
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -33,6 +33,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     SearchAuthors();
                     return this;
                 case "3":
+                    SearchPosts();
                     return this;
                 case "4":
                     return this;
@@ -50,6 +51,22 @@ namespace TabloidCLI.UserInterfaceManagers
             string tagName = Console.ReadLine();
 
             SearchResults<Author> results = _tagRepository.SearchAuthors(tagName);
+
+            if (results.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                results.Display();
+            }
+        }
+        private void SearchPosts()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
+
+            SearchResults<Post> results = _tagRepository.SearchPosts(tagName);
 
             if (results.NoResultsFound)
             {


### PR DESCRIPTION
There isn't a way to add tags to posts currently implemented within the program itself, so you'll have to create a sequel query to make your desired PostTag relationship.

After that, test the feature by navigating to the proper menu and entering the name of your desired tag.

Verify with both an existing and nonexisting tag/relationship.

This feature will not be merged into the master until other features are completed.